### PR TITLE
Fix compilation with Qt >= 5.2

### DIFF
--- a/qeventdispatcher_epoll.h
+++ b/qeventdispatcher_epoll.h
@@ -118,7 +118,11 @@ public:
     QEventDispatcherEpollPrivate(QEventDispatcherEpoll* const q);
     ~QEventDispatcherEpollPrivate();
 
+#if QT_VERSION >= 0x050200
+    int doSelect(QEventLoop::ProcessEventsFlags flags, timespec *timeout);
+#else
     int doSelect(QEventLoop::ProcessEventsFlags flags, timeval *timeout);
+#endif
 
     int thread_pipe[2];
 


### PR DESCRIPTION
timerWait needs timespec as argument (not timeval as in previous versions) [now right version]
